### PR TITLE
Take the values ​​defined in rootProject for Gradle file

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,15 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion safeExtGet('minSdkVersion', 16)
         versionCode 3
         versionName "3.0.0"
         ndk {


### PR DESCRIPTION
By November 2, 2020, all apps that are being updated must target at least Android 10 (API level 29).

The project points to API 28, with the `safeExtGet` function, the project will take the value from the rootProject if it is defined, if it does not take the default. with this your library will not be affected by the new requirement

![image](https://user-images.githubusercontent.com/10731555/96799895-b02c9c80-13c9-11eb-84e1-ceb6c40c3930.png)
