### PR TITLE
fix: update rn peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "0.71.4"
+    "react-native": "0.71.6"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
Fix React Codegen podspec to build on Xcode 14.3 and also will allow the installation of the dependency for the use of RN 71.6
https://github.com/facebook/react-native/commit/0010c3807d7e47d7d518667dbfac62f7c0da1ac1