### PR TITLE
Update package.json to make dependencies more flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,23 +36,23 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@babel/core": "7.13.14",
-    "@babel/runtime": "7.13.10",
-    "@react-native-community/eslint-config": "3.0.1",
-    "@types/jest": "26.0.22",
-    "@types/react-native": "0.64.2",
-    "babel-jest": "26.6.3",
-    "eslint": "7.23.0",
-    "eslint-plugin-simple-import-sort": "10.0.0",
-    "jest": "29.5.0",
-    "metro-react-native-babel-preset": "0.65.2",
-    "react": "18.2.0",
-    "rimraf": "4.4.0",
-    "typescript": "4.9.5"
+    "@babel/core": "^7.13.14",
+    "@babel/runtime": "^7.13.10",
+    "@react-native-community/eslint-config": "^3.0.1",
+    "@types/jest": "^26.0.22",
+    "@types/react-native": "^0.64.2",
+    "babel-jest": "^26.6.3",
+    "eslint": "^7.23.0",
+    "eslint-plugin-simple-import-sort": "^10.0.0",
+    "jest": "^29.5.0",
+    "metro-react-native-babel-preset": "^0.65.2",
+    "react": "^18.2.0",
+    "rimraf": "^4.4.0",
+    "typescript": "^4.9.5"
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "0.71.6"
+    "react-native": "^0.71.6"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
Current dependencies and peer dependencies specs makes lib not usable together with monotrepo / nx as require exact versions of dependencies - which trigger conflicts.

With this change, adding ^ to versions, minor updates (that by [semver](https://semver.org/) do not break backward compatibility) are still alowed