### PR TITLE
Update serveral package versions for better compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,19 +38,18 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.73.6"
   },
   "devDependencies": {
     "@babel/core": "^7.22.5",
     "@babel/runtime": "^7.22.5",
     "@react-native-community/eslint-config": "^3.2.0",
     "@types/jest": "^29.5.2",
-    "@types/react-native": "^0.72.2",
     "babel-jest": "^29.5.0",
     "eslint": "^8.43.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "jest": "^29.5.0",
-    "metro-react-native-babel-preset": "^0.76.7",
+    "metro-react-native-babel-preset": "^0.77.0",
     "react": "^18.2.0",
     "rimraf": "^5.0.1",
     "typescript": "^5.1.3"


### PR DESCRIPTION
Hey,

I updated the react-native package because the old version uses an old version of the Metro bundler, which isn't compatible in newer projects. I also removed the `@types/react-native` package because it was deprecated, and react-native now comes with types included. To conclude with, I also updated the metro babel preset package version to ensure it's compatible with the updated react-native version.