### PR TITLE
Improve: Add TypeScript declaration file paths for better compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",
+  "types": "./lib/typescript/module/src/index.d.ts",
   "exports": {
     ".": {
       "import": {
@@ -15,7 +16,8 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./types": "./lib/typescript/module/src/index.d.ts"
   },
   "files": [
     "src",


### PR DESCRIPTION
Improve: Add TypeScript declaration file paths for better compatibility

- Added `types` field and `./types` export to `package.json` for improved TypeScript type resolution.
- Resolves issues with `Could not find a declaration file for module 'react-native-shake'` in TypeScript projects.