### PR TITLE
fix: exclude generated files to avoid duplicated symbols

### DIFF
--- a/react-native-shake.podspec
+++ b/react-native-shake.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/Doko-Demo-Doa/react-native-shake.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,cpp}"
+  s.exclude_files = "ios/generated/**/*"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## Summary
This PR aims to fix the [duplicate symbol issue](https://github.com/Doko-Demo-Doa/react-native-shake/issues/87) using React Native 0.81 + (Expo SDK 41)

## Notes
Unfortunately, I didn't have time to upgrade the `examples` folder to use the latest React Native